### PR TITLE
feat: added mask support on global logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logger-safe-security",
-  "version": "2.1.0-beta.1",
+  "version": "2.0.0",
   "description": "Custom logging framework used in SAFE",
   "main": "lib/index.js",
   "types": "lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logger-safe-security",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.1",
   "description": "Custom logging framework used in SAFE",
   "main": "lib/index.js",
   "types": "lib",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import winston from "winston";
 
+import { MaskInput } from "./types";
+import mask from "./utils/mask";
+
 const { combine, errors, timestamp, splat, json, metadata } = winston.format;
 
 export const levels = winston.config.npm.levels;
@@ -7,124 +10,144 @@ export const levels = winston.config.npm.levels;
 export type Logger = winston.Logger;
 
 interface ParameterConfig {
-    [key: string]: {
-        /**
-         * Refers the return value of a custom method, in case a value is not found, it should throw an error
-         * to be able to use the fallback value instead
-         */
-        valueFromMethod: <T>(arg: string) => T;
-        /**
-         * This value will be used if the function passed to the valueFromMethod throws an Exception
-         */        
-        fallback?: string;
-    };
+  [key: string]: {
+    /**
+     * Refers the return value of a custom method, in case a value is not found, it should throw an error
+     * to be able to use the fallback value instead
+     */
+    valueFromMethod: <T>(arg: string) => T;
+    /**
+     * This value will be used if the function passed to the valueFromMethod throws an Exception
+     */
+    fallback?: string;
+  };
 }
 interface ConfigParams {
-    parameters: ParameterConfig;
+  parameters: ParameterConfig;
 }
 
-/* A custom format that is used to format the error object. */
-const formatError = winston.format(info => {
-    if ("error" in info && info.error instanceof Error) {
-        const {
-            error: { message, stack, ...rest }
-        } = info;
-        info.error = { message, stack, ...rest };
-    }
+const maskMeta = winston.format((info) => {
+  let parsedInfo = JSON.parse(JSON.stringify(info)) as typeof info & {
+    metadata: MaskInput;
+  };
+  if (parsedInfo.metadata) {
+    parsedInfo = {
+      ...parsedInfo,
+      metadata: mask(parsedInfo.metadata),
+    };
+    return parsedInfo;
+  }
+  return info;
+});
 
-    return info;
+/* A custom format that is used to format the error object. */
+const formatError = winston.format((info) => {
+  if ("error" in info && info.error instanceof Error) {
+    const {
+      error: { message, stack, ...rest },
+    } = info;
+    info.error = { message, stack, ...rest };
+  }
+
+  return info;
 });
 
 /* A custom format that is used to include config parameters. */
 const formatConfigParams = (parameters: ParameterConfig | undefined) => {
-    return winston.format(info => {
-        if (parameters) {
-            Object.keys(parameters).forEach(key => {
-                if (parameters[key]) {
-                    const { valueFromMethod, fallback } = parameters[key];
-                    try {
-                        if (
-                            typeof valueFromMethod === "function" &&
-                            typeof valueFromMethod<string>(key) === "string"
-                        ) {
-                            info[key] = valueFromMethod<string>(key);
-                        }
-                    } catch (error) {
-                        if (fallback) {
-                            info[key] = fallback;
-                        }
-                    }
-                }
-            });
+  return winston.format((info) => {
+    if (parameters) {
+      Object.keys(parameters).forEach((key) => {
+        if (parameters[key]) {
+          const { valueFromMethod, fallback } = parameters[key];
+          try {
+            if (
+              typeof valueFromMethod === "function" &&
+              typeof valueFromMethod<string>(key) === "string"
+            ) {
+              info[key] = valueFromMethod<string>(key);
+            }
+          } catch (error) {
+            if (fallback) {
+              info[key] = fallback;
+            }
+          }
         }
+      });
+    }
 
-        return info;
-    });
+    return info;
+  });
 };
 
 export const createLogger = (
-    {
-        logLevel = "info",
-        service,
-        config
-    }: {
-        logLevel?: string;
-        service?: string;
-        config?: ConfigParams | undefined;
-    } = { logLevel: "info" }
+  {
+    logLevel = "info",
+    service,
+    config,
+  }: {
+    logLevel?: string;
+    service?: string;
+    config?: ConfigParams | undefined;
+  } = { logLevel: "info" }
 ): winston.Logger => {
-    const parameters = config && config.parameters as ParameterConfig | undefined;
+  const parameters =
+    config && (config.parameters as ParameterConfig | undefined);
 
-    return winston.createLogger({
-        // default log level is "info"
-        level: logLevel,
+  return winston.createLogger({
+    // default log level is "info"
+    level: logLevel,
 
-        // combining multiple formats to get the desired output
-        format: combine(
-            // required to log errors thrown by the application; ignored otherwise
-            errors({ stack: true }),
+    // combining multiple formats to get the desired output
+    format: combine(
+      // required to log errors thrown by the application; ignored otherwise
+      errors({ stack: true }),
 
-            // adds timestamp to all log messages
-            timestamp(),
+      // adds timestamp to all log messages
+      timestamp(),
 
-            // enables string interpolation of messages
-            splat(),
+      // enables string interpolation of messages
+      splat(),
 
-            // moves all the other fields in the message to `metadata` property
-            metadata({
-                fillExcept: [
-                    "message",
-                    "level",
-                    "timestamp",
-                    "service",
-                    "type",
-                    "error"
-                ]
-            }),
-            // custom formatter to format the "error" property
-            formatError(),
-
-            // custom formatter to format the config parameters
-            formatConfigParams(parameters)(),
-
-            // default log format is JSON
-            json()
-        ),
-
-        transports: [
-            // logs will be written to console
-            new winston.transports.Console({
-                // catch and log `uncaughtException` events from the application
-                handleExceptions: true,
-
-                // catch and log `uncaughtRejection` events from the application
-                handleRejections: true
-            })
+      // moves all the other fields in the message to `metadata` property
+      metadata({
+        fillExcept: [
+          "message",
+          "level",
+          "timestamp",
+          "service",
+          "type",
+          "error",
         ],
+      }),
 
-        // do not exit the process after logging an uncaughtException
-        exitOnError: false,
+      // mask the metadata
+      maskMeta(),
 
-        // generic metadata applied to all logs
-        defaultMeta: { type: "application", ...(service && { service }) }
-    })};
+      // custom formatter to format the "error" property
+      formatError(),
+
+      // custom formatter to format the config parameters
+      formatConfigParams(parameters)(),
+
+      // default log format is JSON
+      json()
+    ),
+
+    transports: [
+      // logs will be written to console
+      new winston.transports.Console({
+        // catch and log `uncaughtException` events from the application
+        handleExceptions: true,
+
+        // catch and log `uncaughtRejection` events from the application
+        handleRejections: true,
+      }),
+    ],
+
+    // do not exit the process after logging an uncaughtException
+    exitOnError: false,
+
+    // generic metadata applied to all logs
+    defaultMeta: { type: "application", ...(service && { service }) },
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,11 +29,11 @@ interface ConfigParams {
 
 const maskMeta = (maskFields?: string[]) =>
   winston.format((info) => {
-    const parsedInfo = JSON.parse(JSON.stringify(info)) as typeof info & {
+    const parsedInfo = info as typeof info & {
       metadata: MaskInput;
     };
     const metadata = parsedInfo.metadata || {};
-    if (metadata) {
+    if (Object.keys(metadata).length > 0) {
       parsedInfo.metadata = mask(metadata, maskFields);
       return parsedInfo;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,22 +23,22 @@ interface ParameterConfig {
   };
 }
 interface ConfigParams {
-  parameters: ParameterConfig;
+  parameters?: ParameterConfig;
+  maskFields?: string[];
 }
 
-const maskMeta = winston.format((info) => {
-  let parsedInfo = JSON.parse(JSON.stringify(info)) as typeof info & {
-    metadata: MaskInput;
-  };
-  if (parsedInfo.metadata) {
-    parsedInfo = {
-      ...parsedInfo,
-      metadata: mask(parsedInfo.metadata),
+const maskMeta = (maskFields?: string[]) =>
+  winston.format((info) => {
+    const parsedInfo = JSON.parse(JSON.stringify(info)) as typeof info & {
+      metadata: MaskInput;
     };
-    return parsedInfo;
-  }
-  return info;
-});
+    const metadata = parsedInfo.metadata || {};
+    if (metadata) {
+      parsedInfo.metadata = mask(metadata, maskFields);
+      return parsedInfo;
+    }
+    return info;
+  });
 
 /* A custom format that is used to format the error object. */
 const formatError = winston.format((info) => {
@@ -90,8 +90,7 @@ export const createLogger = (
     config?: ConfigParams | undefined;
   } = { logLevel: "info" }
 ): winston.Logger => {
-  const parameters =
-    config && (config.parameters as ParameterConfig | undefined);
+  const parameters = config && config.parameters;
 
   return winston.createLogger({
     // default log level is "info"
@@ -121,7 +120,7 @@ export const createLogger = (
       }),
 
       // mask the metadata
-      maskMeta(),
+      maskMeta(config?.maskFields)(),
 
       // custom formatter to format the "error" property
       formatError(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export type MaskableObject = Record<string, unknown>;
+export type MaskInput = MaskableObject | MaskableObject[] | undefined;

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -10,12 +10,11 @@ import { MaskableObject, MaskInput } from "../types";
 const mask = (
   obj: MaskInput,
   fieldsToMask = [
-    "createdBy",
-    "updatedBy",
     "userName",
     "userEmail",
     "userRole",
     "ownerEmail",
+    "businessOwnerEmail",
   ]
 ): MaskInput => {
   /**

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -1,0 +1,66 @@
+import { MaskableObject, MaskInput } from "../types";
+
+/**
+ * Recursively masks specified fields in an object or array with '***'.
+ * @param {MaskInput} obj - The object or array to mask. Can be undefined.
+ * @param {string[]} [fieldsToMask] - Array of field names to mask.
+ *                                    Defaults to ['createdBy', 'updatedBy', 'userName', 'userEmail', 'userRole']
+ * @returns {MaskInput} The object or array with specified fields masked
+ */
+const mask = (
+  obj: MaskInput,
+  fieldsToMask = [
+    "createdBy",
+    "updatedBy",
+    "userName",
+    "userEmail",
+    "userRole",
+    "ownerEmail",
+  ]
+): MaskInput => {
+  /**
+   * Implementation:
+   * 1. If input is falsy or not an object, return as-is
+   * 2. For arrays, recursively mask each element
+   * 3. For objects:
+   *    - If key matches fieldsToMask, replace value with "***"
+   *    - If value is an object, recursively mask it
+   *    - If value is a JSON string, parse and mask the parsed object
+   *    - Otherwise keep value unchanged
+   * This ensures sensitive fields are masked at any nesting level,
+   * including within serialized JSON strings.
+   */
+  const maskString = "***";
+  if (!obj || typeof obj !== "object") {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => mask(item, fieldsToMask)) as MaskInput;
+  }
+
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => {
+      if (fieldsToMask.includes(key)) {
+        return [key, maskString];
+      }
+
+      if (typeof value === "object" && value !== null) {
+        return [key, mask(value as MaskableObject, fieldsToMask)];
+      }
+
+      if (typeof value === "string" && value.length > 0) {
+        try {
+          const parsedValue = JSON.parse(value) as MaskableObject;
+          return [key, JSON.stringify(mask(parsedValue, fieldsToMask))];
+        } catch (err) {
+          // Not a valid JSON string
+        }
+      }
+
+      return [key, value];
+    })
+  );
+};
+
+export default mask;

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -4,19 +4,10 @@ import { MaskableObject, MaskInput } from "../types";
  * Recursively masks specified fields in an object or array with '***'.
  * @param {MaskInput} obj - The object or array to mask. Can be undefined.
  * @param {string[]} [fieldsToMask] - Array of field names to mask.
- *                                    Defaults to ['createdBy', 'updatedBy', 'userName', 'userEmail', 'userRole']
+ *                                    Defaults to ['userName', 'userEmail']
  * @returns {MaskInput} The object or array with specified fields masked
  */
-const mask = (
-  obj: MaskInput,
-  fieldsToMask = [
-    "userName",
-    "userEmail",
-    "userRole",
-    "ownerEmail",
-    "businessOwnerEmail",
-  ]
-): MaskInput => {
+const mask = (obj: MaskInput, fieldsToMask: string[] = []): MaskInput => {
   /**
    * Implementation:
    * 1. If input is falsy or not an object, return as-is
@@ -29,6 +20,9 @@ const mask = (
    * This ensures sensitive fields are masked at any nesting level,
    * including within serialized JSON strings.
    */
+
+  const maskFieldsSet = new Set(fieldsToMask.concat(["userName", "userEmail"]));
+
   const maskString = "***";
   if (!obj || typeof obj !== "object") {
     return obj;
@@ -40,7 +34,7 @@ const mask = (
 
   return Object.fromEntries(
     Object.entries(obj).map(([key, value]) => {
-      if (fieldsToMask.includes(key)) {
+      if (maskFieldsSet.has(key)) {
         return [key, maskString];
       }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,3 +9,40 @@ logger.info("This is a sample logger with more information", {
 /* Logging the error property. */
 const err = new Error("This is a sample Error");
 logger.info("Error occurred while performing the operation", { error: err });
+
+const metadataWithSensitiveData = {
+  planet: "Earth",
+  userEmail: "test@test.com",
+  userName: "John Doe",
+  userRole: "admin",
+  userId: 1234567890,
+  nesting: {
+    userEmail: "test@test.com",
+    userName: "John Doe",
+    userRole: "admin",
+    userId: 1234567890,
+    stringified: JSON.stringify({
+      userEmail: "test@test.com",
+      userName: "John Doe",
+      userRole: "admin",
+      userId: 1234567890,
+    }),
+  },
+};
+
+// mask the metadata
+logger.info(
+  "This is a sample logger with masked metadata",
+  metadataWithSensitiveData
+);
+
+const loggerWithCustomMaskFields = createLogger({
+  config: {
+    maskFields: ["userEmail"],
+  },
+});
+
+loggerWithCustomMaskFields.info(
+  "This is a sample logger with masked metadata",
+  metadataWithSensitiveData
+);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,6 +28,12 @@ const metadataWithSensitiveData = {
       userId: 1234567890,
     }),
   },
+  array: [
+    { userEmail: "test@test.com" },
+    { userName: "John Doe" },
+    { userRole: "admin" },
+    { userId: 1234567890 },
+  ],
 };
 
 // mask the metadata

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,7 +44,7 @@ logger.info(
 
 const loggerWithCustomMaskFields = createLogger({
   config: {
-    maskFields: ["userEmail"],
+    maskFields: ["userRole"],
   },
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "logger-safe-security";
+
 const logger = createLogger({ service: "sample" });
 
 logger.info("This is a sample logger");
@@ -9,3 +10,40 @@ logger.info("This is a sample logger with more information", {
 /* Logging the error property. */
 const err = new Error("This is a sample Error");
 logger.info("Error occurred while performing the operation", { error: err });
+
+const metadataWithSensitiveData = {
+  planet: "Earth",
+  userEmail: "test@test.com",
+  userName: "John Doe",
+  userRole: "admin",
+  userId: 1234567890,
+  nesting: {
+    userEmail: "test@test.com",
+    userName: "John Doe",
+    userRole: "admin",
+    userId: 1234567890,
+    stringified: JSON.stringify({
+      userEmail: "test@test.com",
+      userName: "John Doe",
+      userRole: "admin",
+      userId: 1234567890,
+    }),
+  },
+};
+
+// mask the metadata
+logger.info(
+  "This is a sample logger with masked metadata",
+  metadataWithSensitiveData
+);
+
+const loggerWithCustomMaskFields = createLogger({
+  config: {
+    maskFields: ["userEmail"],
+  },
+});
+
+loggerWithCustomMaskFields.info(
+  "This is a sample logger with masked metadata",
+  metadataWithSensitiveData
+);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -45,7 +45,7 @@ logger.info(
 
 const loggerWithCustomMaskFields = createLogger({
   config: {
-    maskFields: ["userEmail"],
+    maskFields: ["userRole"],
   },
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -29,6 +29,12 @@ const metadataWithSensitiveData = {
       userId: 1234567890,
     }),
   },
+  array: [
+    { userEmail: "test@test.com" },
+    { userName: "John Doe" },
+    { userRole: "admin" },
+    { userId: 1234567890 },
+  ],
 };
 
 // mask the metadata

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,8 +2,9 @@ import { createLogger } from "logger-safe-security";
 const logger = createLogger({ service: "sample" });
 
 logger.info("This is a sample logger");
-logger.info("This is a sample logger with more information", { planet: "Earth" });
-
+logger.info("This is a sample logger with more information", {
+  planet: "Earth",
+});
 
 /* Logging the error property. */
 const err = new Error("This is a sample Error");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2020",
     "module": "commonjs",
     "declaration": true,
     "declarationMap": false,


### PR DESCRIPTION
This PR adds a support to mask sensitive fields using the global logger.
Default masked fields - 
- userName
- userEmail

A user can configure mask fields by providing `config.maskFields` as a string array while creating the logger instance.